### PR TITLE
build-and-push: Add a unique tag

### DIFF
--- a/workflow-templates/build-and-push.yml
+++ b/workflow-templates/build-and-push.yml
@@ -32,8 +32,9 @@ jobs:
                   tag="prod"
                   ;;
           esac
-          echo "::set-output name=branch::$branch"
-          echo "::set-output name=tag::$tag"
+          echo "::set-output name=branch::${branch}"
+          unique_tag="${branch}-${GITHUB_SHA::7}"
+          echo "::set-output name=tag::${tag} ${unique_tag}"
         id: branch_tag
 
       - name: Build Image


### PR DESCRIPTION
This prevents older images from being garbage collected from the registry once a newer stg/prod image is built.

Fixes #2