### PR TITLE
Create organization issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report a bug
+labels: kind/bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues to avoid creating duplicates.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened? What is the problem?
+      description: |
+        Please provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expectation
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: false
+
+  - type: textarea
+    id: example-url
+    attributes:
+      label: Example URL(s)
+      description: Please provide URL(s) with example of the issue.
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1.
+        2.
+        3.
+      render: bash
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Workaround
+      options:
+        - label: There is an existing workaround that can be used until this issue is fixed.
+          required: false
+
+  - type: checkboxes
+    attributes:
+      label: Participation
+      options:
+        - label: I am willing to submit a pull request for this issue. (Packit team is happy to help!)
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Request a feature
+labels: kind/feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing issues to avoid creating duplicates.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefit
+    attributes:
+      label: Benefit
+      description: Please provide the benefits of this feature. Do you know if this could be beneficial for other users too?
+    validations:
+      required: false
+
+  - type: textarea
+    id: importance
+    attributes:
+      label: Importance
+      description: How important is this feature for you (or your team)? Is this something that is blocking you from using the repository?
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Workaround
+      options:
+        - label: There is an existing workaround that can be used until this feature is implemented.
+          required: false
+
+  - type: checkboxes
+    attributes:
+      label: Participation
+      options:
+        - label: I am willing to submit a pull request for this issue. (Packit team is happy to help!)
+          required: false


### PR DESCRIPTION
These will be used by default by all repositories in the organization without present .github/ISSUE_TEMPLATE directory, see https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file.