### PR TITLE
fix: every release note text being changed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,5 @@ Merge before/after
 <!-- release notes footer -->
 
 RELEASE NOTES BEGIN
-
-Packit now supports automatic ordering of ☕ after all checks pass.
-
+￼
 RELEASE NOTES END


### PR DESCRIPTION
Changes the 
```
RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
```
to

```
RELEASE NOTES BEGIN
￼
RELEASE NOTES END
```